### PR TITLE
fix: stabilize editor serialization

### DIFF
--- a/admin/src/components/ContentEditable.tsx
+++ b/admin/src/components/ContentEditable.tsx
@@ -1,70 +1,236 @@
-import React, { forwardRef, SyntheticEvent, useEffect, useRef, useState } from 'react';
+import React, { forwardRef, SyntheticEvent, useEffect, useRef } from 'react';
+import { parse, NodeType } from 'node-html-parser';
+
+type ParsedNode = { type: 'break' } | { type: 'text'; bold: boolean; text: string };
+
+const normalizeText = (text: string) => text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+const textToNodes = (text: string, bold: boolean) => {
+    return normalizeText(text).split('\n').reduce((nodes: ParsedNode[], segment: string, index: number) => {
+        if (index > 0) {
+            nodes.push({ type: 'break' });
+        }
+
+        if (segment.length > 0) {
+            nodes.push({ type: 'text', text: segment, bold });
+        }
+
+        return nodes;
+    }, []);
+};
+
+const isPlaceholderBlock = (node: any) => {
+    return (
+        (node.tagName === 'DIV' || node.tagName === 'P') &&
+        node.childNodes.length === 1 &&
+        node.childNodes[0].nodeType === NodeType.ELEMENT_NODE &&
+        node.childNodes[0].tagName === 'BR'
+    );
+};
+
+const isBoldElement = (node: any) => {
+    if (node.tagName === 'B' || node.tagName === 'STRONG') {
+        return true;
+    }
+
+    const style = node.getAttribute?.('style') ?? '';
+    return /font-weight\s*:\s*(bold|[6-9]00)/i.test(style);
+};
+
+const reduceParsed = (html: any, bold: boolean = false) => {
+    return html.childNodes.reduce((nodes: ParsedNode[], child: any, index: number) => {
+        if (child.nodeType === NodeType.TEXT_NODE) {
+            return [...nodes, ...textToNodes(child.text, bold)];
+        }
+
+        if (child.nodeType !== NodeType.ELEMENT_NODE) {
+            return nodes;
+        }
+
+        if (child.tagName === 'BR') {
+            return [...nodes, { type: 'break' }];
+        }
+
+        if (child.tagName === 'DIV' || child.tagName === 'P') {
+            const withBreak = index > 0 ? [...nodes, { type: 'break' }] : nodes;
+
+            if (child.childNodes.length === 0 || isPlaceholderBlock(child)) {
+                return withBreak;
+            }
+
+            return [...withBreak, ...reduceParsed(child, bold)];
+        }
+
+        if (isBoldElement(child)) {
+            return [...nodes, ...reduceParsed(child, true)];
+        }
+
+        if (child.childNodes && child.childNodes.length > 0) {
+            return [...nodes, ...reduceParsed(child, bold)];
+        }
+
+        return nodes;
+    }, []);
+};
+
+const escapeHtml = (text: string) => {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+};
+
+const onlyBreaks = (parsed: ParsedNode[]) => parsed.length > 0 && parsed.every((node) => node.type === 'break');
+
+const toMarkdown = (parsed: ParsedNode[], clear: boolean) => {
+    return parsed.reduce((html: string, node: ParsedNode) => {
+        if (node.type === 'break') {
+            return `${html}  \n`;
+        }
+
+        if (node.type === 'text' && node.bold && !clear) {
+            return `${html}**${clear ? node.text.replace(/(\n)/gm, '') : node.text}**`;
+        }
+
+        if (node.type === 'text') {
+            return html + (clear ? node.text.replace(/(\n)/gm, '') : node.text);
+        }
+
+        return html;
+    }, '');
+};
+
+const toHtml = (parsed: ParsedNode[], clear: boolean) => {
+    return parsed.reduce((html: string, node: ParsedNode) => {
+        if (node.type === 'break') {
+            return `${html}<br>`;
+        }
+
+        if (node.type === 'text' && node.bold && !clear) {
+            return `${html}<b>${escapeHtml(node.text)}</b>`;
+        }
+
+        if (node.type === 'text') {
+            return html + escapeHtml(node.text);
+        }
+
+        return html;
+    }, '');
+};
+
+const normalizeHtmlValue = (html: string) => {
+    const parsed = reduceParsed(parse(html ?? ''));
+
+    if (onlyBreaks(parsed)) {
+        return '';
+    }
+
+    return toHtml(parsed, false);
+};
+
+export const getValueToUpdate = (html: string, markdown: boolean, clear: boolean = false) => {
+    const parsed = reduceParsed(parse(html ?? ''));
+
+    if (onlyBreaks(parsed)) {
+        return '';
+    }
+
+    return markdown ? toMarkdown(parsed, clear) : toHtml(parsed, clear);
+};
+
+export const getPasteHtml = (html: string, plainText: string) => {
+    if (html) {
+        return normalizeHtmlValue(html);
+    }
+
+    return normalizeText(plainText).split('\n').map(escapeHtml).join('<br>');
+};
 
 type ContentEditableEvent = React.SyntheticEvent<any, Event> & { target: { value: string } };
 type Modify<T, R> = Pick<T, Exclude<keyof T, keyof R>> & R;
-type DivProps = Modify<React.JSX.IntrinsicElements["div"], { onChange: ((event: ContentEditableEvent) => void) }>;
+type DivProps = Modify<React.JSX.IntrinsicElements['div'], { onChange: (event: ContentEditableEvent) => void }>;
 
 interface Props extends DivProps {
-  html: string;
-  disabled?: boolean;
-  tagName?: string;
-  className?: string;
-  style?: Object;
-  innerRef?: React.RefObject<HTMLElement> | Function;
+    html: string;
+    disabled?: boolean;
+    tagName?: string;
+    className?: string;
+    style?: Object;
+    innerRef?: React.RefObject<HTMLElement> | Function;
 }
 
+const updateRef = (ref: React.Ref<HTMLElement> | undefined, value: HTMLElement | null) => {
+    if (!ref) {
+        return;
+    }
+
+    if (typeof ref === 'function') {
+        ref(value);
+        return;
+    }
+
+    (ref as React.MutableRefObject<HTMLElement | null>).current = value;
+};
+
 const ContentEditable = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
-  const { html, innerRef, children, ...rest } = props;
-  const [lastHtml, setLastHtml] = useState('');
-  const divRef = ref as React.RefObject<HTMLDivElement>;
-  const caretRangeRef = useRef<Range | null>(null);
+    const { html, innerRef, children, ...rest } = props;
+    const divRef = useRef<HTMLDivElement | null>(null);
+    const lastHtmlRef = useRef('');
 
-  const saveCaretPosition = () => {
-    const selection = window.getSelection();
-    if (selection && selection.rangeCount > 0) {
-      caretRangeRef.current = selection.getRangeAt(0);
-    }
-  };
+    const emitChange = (originalEvt: SyntheticEvent<any>) => {
+        const el = divRef.current;
+        if (!el) return;
 
-  const emitChange = (originalEvt: SyntheticEvent<any>) => {
-    const el = divRef.current;
-    if (!el) return;
-    saveCaretPosition();
+        const currentHtml = normalizeHtmlValue(el.innerHTML);
 
-    const currentHtml = el.innerHTML;
-    if (currentHtml !== lastHtml) {
-      const evt = Object.assign({}, originalEvt, {
-        target: {
-          value: currentHtml,
-        },
-      });
-      props.onChange(evt);
-      setLastHtml(currentHtml);
-    }
-  };
+        if (currentHtml !== lastHtmlRef.current) {
+            const evt = Object.assign({}, originalEvt, {
+                target: {
+                    value: currentHtml,
+                },
+            });
+            props.onChange(evt);
+        }
 
-  useEffect(() => {
-    const el = divRef.current;
-    if (el && html !== lastHtml) {
-      el.innerHTML = html;
-      setLastHtml(html);
-    }
-  }, [html]);
+        lastHtmlRef.current = currentHtml;
+    };
 
-  return (
-    <div
-      {...rest}
-      ref={divRef}
-      onInput={emitChange}
-      onBlur={rest.onBlur || emitChange}
-      onKeyUp={rest.onKeyUp || emitChange}
-      onKeyDown={rest.onKeyDown || emitChange}
-      contentEditable={!rest.disabled}
-      style={{ whiteSpace: 'pre-wrap', ...props.style }}
-    >
-      {children}
-    </div>
-  );
+    useEffect(() => {
+        const el = divRef.current;
+        const nextHtml = normalizeHtmlValue(html);
+
+        if (!el) {
+            return;
+        }
+
+        if (nextHtml !== normalizeHtmlValue(el.innerHTML)) {
+            el.innerHTML = html;
+        }
+
+        lastHtmlRef.current = nextHtml;
+    }, [html]);
+
+    useEffect(() => {
+        updateRef(ref as React.Ref<HTMLElement> | undefined, divRef.current);
+        updateRef(innerRef as React.Ref<HTMLElement> | undefined, divRef.current);
+    }, [innerRef, ref]);
+
+    return (
+        <div
+            {...rest}
+            ref={divRef}
+            onInput={emitChange}
+            onBlur={rest.onBlur || emitChange}
+            onKeyUp={rest.onKeyUp || emitChange}
+            onKeyDown={rest.onKeyDown || emitChange}
+            contentEditable={!rest.disabled}
+            style={{ whiteSpace: 'pre-wrap', ...props.style }}
+        >
+            {children}
+        </div>
+    );
 });
 
 export default ContentEditable;

--- a/admin/src/components/Input.tsx
+++ b/admin/src/components/Input.tsx
@@ -2,9 +2,8 @@ import React, { useState, useRef } from 'react';
 import styled from 'styled-components';
 import { Box, Flex, Typography, IconButton, inputFocusStyle } from '@strapi/design-system';
 import { Earth, Bold, Code, StrikeThrough, Cross } from '@strapi/icons';
-import ReactContentEditable from './ContentEditable';
+import ReactContentEditable, { getPasteHtml, getValueToUpdate } from './ContentEditable';
 import showdown from 'showdown';
-import { parse, NodeType } from 'node-html-parser';
 
 interface InputProps {
     name: string;
@@ -56,74 +55,6 @@ const executeCommand = (commandId: string, value?: string) => {
     document.execCommand(commandId, false, value);
 };
 
-const reduceParsed = (html: any, bold: boolean = false) => {
-    return html.childNodes.reduce((a: any, c: any) => {
-        if (c.nodeType === NodeType.TEXT_NODE) {
-            return [...a, { type: 'text', text: c.text, bold: !!bold }];
-        }
-
-        if (c.nodeType === NodeType.ELEMENT_NODE && c.tagName === 'BR') {
-            return [...a, { type: 'break' }];
-        }
-
-        if (c.nodeType === NodeType.ELEMENT_NODE && c.childNodes && (c.tagName === 'B' || c.tagName === 'STRONG')) {
-            return [...a, ...reduceParsed(c, true)];
-        }
-
-        if (c.nodeType === NodeType.ELEMENT_NODE && c.childNodes && c.childNodes.length > 0) {
-            return [...a, ...reduceParsed(c)];
-        }
-
-        return a;
-    }, []);
-};
-
-const toMarkdown = (parsed: any, clear: any) => {
-    return parsed.reduce((a: any, c: any) => {
-        if (c.type === 'break' && !clear) {
-            return `${a}  \n`;
-        }
-
-        if (c.type === 'text' && c.bold && !clear) {
-            return `${a}**${clear ? c.text.replace(/(\n)/gm, '') : c.text}**`;
-        }
-
-        if (c.type === 'text') {
-            return a + (clear ? c.text.replace(/(\n)/gm, '') : c.text);
-        }
-
-        return a;
-    }, '');
-};
-
-const toHtml = (parsed: any, clear: any) => {
-    return parsed.reduce((a: any, c: any) => {
-        if (c.type === 'break' && !clear) {
-            return clear ? a : `${a}<br>`;
-        }
-
-        if (c.type === 'text' && c.bold && !clear) {
-            return `${a}<b>${c.text}</b>`;
-        }
-
-        if (c.type === 'text') {
-            return a + c.text;
-        }
-
-        return a;
-    }, '');
-};
-
-const getValueToUpdate = (html: any, markdown: any, clear?: any) => {
-    const parsed = reduceParsed(parse(html));
-
-    if (parsed.every((node: any) => node.type === 'break')) {
-        return '';
-    }
-
-    return markdown ? toMarkdown(parsed, clear) : toHtml(parsed, clear);
-};
-
 const getHtml = (value: any, markdown: any) => {
     return value && markdown ? converter.makeHtml(value) : (value ?? '');
 };
@@ -140,7 +71,7 @@ const Input = ({
     placeholder,
     hint,
 }: InputProps) => {
-    const ref = useRef();
+    const ref = useRef<HTMLDivElement | null>(null);
     const [preview, setPreview] = useState(false);
 
     const markdown = !!(attribute.options && attribute.options.output === 'markdown');
@@ -152,14 +83,16 @@ const Input = ({
 
     const handleOnPaste = (event: any) => {
         event.preventDefault();
-        const plainText = event.clipboardData.getData('text/plain');
-        const html = event.clipboardData.getData('text/html');
+        const plainText = event.clipboardData.getData('text/plain') ?? '';
+        const html = event.clipboardData.getData('text/html') ?? '';
+        const pastedHtml = getPasteHtml(html, plainText);
 
-        update(getValueToUpdate(html || plainText, markdown));
+        executeCommand('insertHTML', pastedHtml);
+        update(getValueToUpdate(ref.current?.innerHTML ?? '', markdown));
     };
 
     const handleOnChange = (event: any) => {
-        update(getValueToUpdate(getHtml(event.target.value, markdown), markdown));
+        update(getValueToUpdate(event.target.value, markdown));
     };
 
     const handleOnClear = () => {
@@ -172,8 +105,7 @@ const Input = ({
 
     const handleOnKeyDown = (event: any) => {
         if (event.key === 'Escape') {
-            // @ts-ignore
-            ref?.current?.blur();
+            ref.current?.blur();
         }
     };
 
@@ -181,8 +113,7 @@ const Input = ({
 
     const _disabled = Boolean(disabled || false);
 
-
-  return (
+    return (
         <Box>
             {label && (
                 <Flex paddingBottom={1}>
@@ -203,7 +134,6 @@ const Input = ({
             )}
             <Flex gap={2}>
                 <ContentEditable
-                    // @ts-ignore
                     ref={ref}
                     html={getHtml(value, markdown)}
                     onPaste={handleOnPaste}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@sklinet/strapi-plugin-bold-title-editor",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@sklinet/strapi-plugin-bold-title-editor",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "license": "MIT",
             "dependencies": {
                 "@strapi/design-system": "^2.0.0-rc.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sklinet/strapi-plugin-bold-title-editor",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "A bold title/text editor to accent certain parts",
     "keywords": [],
     "license": "MIT",


### PR DESCRIPTION
- normalize editor HTML before syncing DOM to avoid caret jumps
- preserve special characters and consecutive line breaks on save
- insert pasted content at caret and keep plain/rich text formatting stable
- colocate normalization logic with ContentEditable